### PR TITLE
Add script portability accross UNIX like operating system.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,3 +26,5 @@ jobs:
       uses: actions/checkout@v2
     - name: Run mdl
       uses: actionshub/markdownlint@main
+      with:
+        filesToIgnoreRegex: "CHANGELOG.md"

--- a/log4bash.sh
+++ b/log4bash.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #####
 ## Create logging bash library


### PR DESCRIPTION
- Add script portability accross UNIX like operating system.
- Exclude CHANGELOG.md file from markdown linter.
