### PR TITLE
fix(logbash): LOG_OUTPUT_FORMAT unbound variable

### DIFF
--- a/log4bash.sh
+++ b/log4bash.sh
@@ -30,6 +30,8 @@ declare MAX_MESSAGE_LENGTH="${MAX_MESSAGE_LENGTH:=100}"
 declare ENABLE_COLOR="${ENABLE_COLOR:=1}"
 # Output log destination (console, file)
 declare LOG_OUTPUT_STRATEGY="${LOG_OUTPUT_STRATEGY:=console}"
+# Init log output format variable
+declare LOG_OUTPUT_FORMAT="${LOG_OUTPUT_FORMAT:=""}"
 
 # --- Color Codes ---
 # Note: Only used if terminal supports colors and ENABLE_COLOR=1


### PR DESCRIPTION
Fix `LOG_OUTPUT_FORMAT` unbound variable when importing into script with `set -euo pipefail`